### PR TITLE
Type cast attributes when updating to dictionary

### DIFF
--- a/console.py
+++ b/console.py
@@ -108,7 +108,8 @@ class HBNBCommand(cmd.Cmd):
         args = parse(line)
         if len(args) >= 4:
             key = "{}.{}".format(args[0], args[1])
-            setattr(storage.all()[key], args[2], args[3])
+            cast = type(eval(args[3]))
+            setattr(storage.all()[key], args[2], cast(args[3]))
             storage.all()[key].save()
         elif len(args) == 0:
             print("** class name missing **")

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -164,7 +164,7 @@ class TestConsole(unittest.TestCase):
         """Test cmd output: <class>.<cmd>"""
         with patch('sys.stdout', new=StringIO()) as fake_output:
             self.typing.onecmd("User.count()")
-            self.assertEqual('0\n', fake_output.getvalue())
+            self.assertEqual(int, type(eval(fake_output.getvalue())))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
You can take a look at the casting. Before updating (setattr), we can evaluate the parameter given by the user and cast it accordingly. If the user gives "User.update("123", "age", 9)", we can correctly store 9 as an int in the dict. But it doesn't prevent them from writing  "User.update("123", "age", "nine")." If we wanted to handle that, we'd just add more if statements to check what type the attribute should be. Don't know if it's necessary at this point.